### PR TITLE
Build docker artifact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:10.12.0-alpine AS build-env
+# leveldown dependency requires python
+RUN apk --update --no-cache add python build-base
+
+ADD . /app
+WORKDIR /app
+RUN yarn install; yarn run build
+
+FROM node:10.12.0-alpine
+
+COPY --from=build-env /app/bin /app/bin
+COPY --from=build-env /app/build /app/build
+COPY --from=build-env /app/node_modules /app/node_modules
+WORKDIR /app
+
+EXPOSE 8000
+ENTRYPOINT [ "/app/bin/iov-faucet"]
+CMD [""]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,23 @@ with
 * `account_index`: 0-based index of the account. Account 0 is the token holder and
    account 1...FAUCET_CONCURRENCY are the distributor accounts.
 
+
+### Working with docker 
+* Build an artifact
+```bash
+docker build -t iov-faucet:manual .
+```
+
+* Init DB
+```bash
+docker run --read-only -v $(pwd)/tmp:/app/db --rm iov-faucet:manual init db/test.db password bns "degree tackle suggest window test behind mesh extra cover prepare oak script"
+```
+
+* Run faucet
+```bash
+docker run --read-only -v $(pwd)/tmp:/app/db -p 8000:8000 --rm iov-faucet:manual start db/test.db password bns wss://bov.friendnet-fast.iov.one
+```
+
 ### Using the faucet
 
 Now that the faucet has been started up, you can send credit requests to it. This can be done with a simple http POST request. These commands assume the faucet is running locally, be sure to change it from `localhost` if your situation is different.


### PR DESCRIPTION
- Adds a Dockerfile and doc in Readme to build and run

To make this work on our testnets there are some steps left. Please copy them to your backlog/ issues if they make sense for you, too.

### Required for k8s hosting
- [ ] I assumed the name of the docker artifact is `iov-faucet`. Is this correct?- We need to create a repo on docker [hub](https://hub.docker.com/u/iov1/)
- [ ] allow db file to exist on init: **don't fail** - if we need a persistent disk for the faucet to run, we use an init container that executes the init step. On any redeployment the init step is executed again and must not fail

### Best practices
- [ ] Build artifact and push to docker hub with travisCI
- [ ] grafully shutdown on Sigterm

- [ ] add health-check endpoint `/healthz` - I will configure kubernetes to call this url to check if the service is still up and running. if it returns http code != 200 the container is restarted
- [ ] add readiness endpoint `/status` - requests are only routed to instances that are ready. if the faucet can not immediately handle requests on startup (for example it refills itself) or later, this endpoint should return !=200 http code to be temporary removed from loadbalancing.
- [ ] add prometheus metrics endpoint `/metrics` - provide relevant metrics like request count and duration as well as service/ account KPIs. See https://github.com/siimon/prom-client

See https://github.com/iov-one/ops/wiki/Writing-a-new-app-for-Kubernetes for more



