### PR TITLE
Add content to home route "/"; simplify /healthz

### DIFF
--- a/src/actions/start/start.ts
+++ b/src/actions/start/start.ts
@@ -78,7 +78,16 @@ export async function start(args: ReadonlyArray<string>): Promise<void> {
 
   api.use(async context => {
     switch (context.path) {
+      case "/":
       case "/healthz":
+        // tslint:disable-next-line:no-object-mutation
+        context.response.body =
+          "Welcome to the faucet!\n" +
+          "\n" +
+          "Check the full status via the /status endpoint.\n" +
+          "You can get tokens from here by POSTing to /credit.\n" +
+          "See https://github.com/iov-one/iov-faucet for all further information.\n";
+        break;
       case "/status":
         const updatedAccounts = await accountsOfFirstChain(profile, signer);
         // tslint:disable-next-line:no-object-mutation


### PR DESCRIPTION
Closes #33

@alpe does this do the job?


----------

Example call

```
curl -v http://localhost:8000/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8000 (#0)
> GET / HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Vary: Origin
< Content-Type: text/plain; charset=utf-8
< Content-Length: 195
< Date: Thu, 28 Feb 2019 18:14:13 GMT
< Connection: keep-alive
< 
Welcome to the faucet!

Check the full status via the /status endpoint.
You can get tokens from here by POSTing to /credit.
See https://github.com/iov-one/iov-faucet for all further information.
```